### PR TITLE
Add the test suite purge-cache

### DIFF
--- a/src/leofs_test.hrl
+++ b/src/leofs_test.hrl
@@ -89,6 +89,7 @@
 
 
 %% TEST Scenatios:
+-define(F_DUMP_RING,            dump_ring).
 -define(F_PURGE_CACHE,          purge_cache).
 -define(F_PUT_OBJ,              put_objects).
 -define(F_PUT_ZERO_BYTE_OBJ,    put_zero_byte_objects).
@@ -121,6 +122,7 @@
 -define(F_MP_UPLOAD_ABORT,              mp_upload_abort).
 -define(F_MP_UPLOAD_INVALID_COMPLETE,   mp_upload_invalid_complete).
 
+-define(SC_ITEM_DUMP_RING,            {?F_DUMP_RING,            "dump ring data to the local disk"}).
 -define(SC_ITEM_PURGE_CACHE,          {?F_PURGE_CACHE,          "remove a cache from each gateway"}).
 -define(SC_ITEM_PUT_OBJ,              {?F_PUT_OBJ,              "put objects"}).
 -define(SC_ITEM_PUT_ZERO_BYTE_OBJ,    {?F_PUT_ZERO_BYTE_OBJ,    "put zero byte objects"}).
@@ -152,7 +154,8 @@
 -define(SC_ITEM_MP_UPLOAD_NORMAL_IN_PARALLEL, {?F_MP_UPLOAD_NORMAL_IN_PARALLEL, "multipart upload in parallel"}).
 -define(SC_ITEM_MP_UPLOAD_ABORT, {?F_MP_UPLOAD_ABORT, "abort multipart upload"}).
 -define(SC_ITEM_MP_UPLOAD_INVALID_COMPLETE, {?F_MP_UPLOAD_INVALID_COMPLETE, "invalid complete multipart upload"}).
--define(SC_ITEMS, [?SC_ITEM_PURGE_CACHE,
+-define(SC_ITEMS, [?SC_ITEM_DUMP_RING,
+                   ?SC_ITEM_PURGE_CACHE,
                    ?SC_ITEM_PUT_OBJ,
                    ?SC_ITEM_GET_OBJ,
                    ?SC_ITEM_GET_OBJ_NOT_FOUND,
@@ -188,7 +191,8 @@
                                       ?SC_ITEM_CHECK_REPLICAS
                                      ]}).
 
--define(SCENARIO_1, {"SCENARIO-1", [?SC_ITEM_CREATE_BUCKET,
+-define(SCENARIO_1, {"SCENARIO-1", [?SC_ITEM_DUMP_RING,
+                                    ?SC_ITEM_CREATE_BUCKET,
                                     ?SC_ITEM_PURGE_CACHE,
                                     ?SC_ITEM_RECOVER_FILE,
                                     ?SC_ITEM_GET_OBJ_NOT_FOUND,

--- a/src/leofs_test.hrl
+++ b/src/leofs_test.hrl
@@ -89,6 +89,7 @@
 
 
 %% TEST Scenatios:
+-define(F_UPDATE_LOG_LEVEL,     update_log_level).
 -define(F_DUMP_RING,            dump_ring).
 -define(F_PURGE_CACHE,          purge_cache).
 -define(F_PUT_OBJ,              put_objects).
@@ -122,6 +123,7 @@
 -define(F_MP_UPLOAD_ABORT,              mp_upload_abort).
 -define(F_MP_UPLOAD_INVALID_COMPLETE,   mp_upload_invalid_complete).
 
+-define(SC_ITEM_UPDATE_LOG_LEVEL,     {?F_UPDATE_LOG_LEVEL,     "update log level of a node"}).
 -define(SC_ITEM_DUMP_RING,            {?F_DUMP_RING,            "dump ring data to the local disk"}).
 -define(SC_ITEM_PURGE_CACHE,          {?F_PURGE_CACHE,          "remove a cache from each gateway"}).
 -define(SC_ITEM_PUT_OBJ,              {?F_PUT_OBJ,              "put objects"}).
@@ -154,7 +156,8 @@
 -define(SC_ITEM_MP_UPLOAD_NORMAL_IN_PARALLEL, {?F_MP_UPLOAD_NORMAL_IN_PARALLEL, "multipart upload in parallel"}).
 -define(SC_ITEM_MP_UPLOAD_ABORT, {?F_MP_UPLOAD_ABORT, "abort multipart upload"}).
 -define(SC_ITEM_MP_UPLOAD_INVALID_COMPLETE, {?F_MP_UPLOAD_INVALID_COMPLETE, "invalid complete multipart upload"}).
--define(SC_ITEMS, [?SC_ITEM_DUMP_RING,
+-define(SC_ITEMS, [?SC_ITEM_UPDATE_LOG_LEVEL,
+                   ?SC_ITEM_DUMP_RING,
                    ?SC_ITEM_PURGE_CACHE,
                    ?SC_ITEM_PUT_OBJ,
                    ?SC_ITEM_GET_OBJ,
@@ -191,7 +194,8 @@
                                       ?SC_ITEM_CHECK_REPLICAS
                                      ]}).
 
--define(SCENARIO_1, {"SCENARIO-1", [?SC_ITEM_DUMP_RING,
+-define(SCENARIO_1, {"SCENARIO-1", [?SC_ITEM_UPDATE_LOG_LEVEL,
+                                    ?SC_ITEM_DUMP_RING,
                                     ?SC_ITEM_CREATE_BUCKET,
                                     ?SC_ITEM_PURGE_CACHE,
                                     ?SC_ITEM_RECOVER_FILE,

--- a/src/leofs_test.hrl
+++ b/src/leofs_test.hrl
@@ -89,6 +89,7 @@
 
 
 %% TEST Scenatios:
+-define(F_PURGE_CACHE,          purge_cache).
 -define(F_PUT_OBJ,              put_objects).
 -define(F_PUT_ZERO_BYTE_OBJ,    put_zero_byte_objects).
 -define(F_PUT_INCONSISTENT_OBJ, put_inconsistent_objects).
@@ -120,6 +121,7 @@
 -define(F_MP_UPLOAD_ABORT,              mp_upload_abort).
 -define(F_MP_UPLOAD_INVALID_COMPLETE,   mp_upload_invalid_complete).
 
+-define(SC_ITEM_PURGE_CACHE,          {?F_PURGE_CACHE,          "remove a cache from each gateway"}).
 -define(SC_ITEM_PUT_OBJ,              {?F_PUT_OBJ,              "put objects"}).
 -define(SC_ITEM_PUT_ZERO_BYTE_OBJ,    {?F_PUT_ZERO_BYTE_OBJ,    "put zero byte objects"}).
 -define(SC_ITEM_PUT_INCONSISTENT_OBJ, {?F_PUT_INCONSISTENT_OBJ, "put inconsistent objects"}).
@@ -150,7 +152,8 @@
 -define(SC_ITEM_MP_UPLOAD_NORMAL_IN_PARALLEL, {?F_MP_UPLOAD_NORMAL_IN_PARALLEL, "multipart upload in parallel"}).
 -define(SC_ITEM_MP_UPLOAD_ABORT, {?F_MP_UPLOAD_ABORT, "abort multipart upload"}).
 -define(SC_ITEM_MP_UPLOAD_INVALID_COMPLETE, {?F_MP_UPLOAD_INVALID_COMPLETE, "invalid complete multipart upload"}).
--define(SC_ITEMS, [?SC_ITEM_PUT_OBJ,
+-define(SC_ITEMS, [?SC_ITEM_PURGE_CACHE,
+                   ?SC_ITEM_PUT_OBJ,
                    ?SC_ITEM_GET_OBJ,
                    ?SC_ITEM_GET_OBJ_NOT_FOUND,
                    ?SC_ITEM_DEL_OBJ,
@@ -186,6 +189,7 @@
                                      ]}).
 
 -define(SCENARIO_1, {"SCENARIO-1", [?SC_ITEM_CREATE_BUCKET,
+                                    ?SC_ITEM_PURGE_CACHE,
                                     ?SC_ITEM_RECOVER_FILE,
                                     ?SC_ITEM_GET_OBJ_NOT_FOUND,
                                     ?SC_ITEM_PUT_ZERO_BYTE_OBJ,

--- a/src/leofs_test_commons.erl
+++ b/src/leofs_test_commons.erl
@@ -32,6 +32,7 @@
 -define(DETACH_NODE_1, 'storage_0@127.0.0.1').
 -define(SUSPEND_NODE,  'storage_1@127.0.0.1').
 -define(RESUME_NODE,   'storage_1@127.0.0.1').
+-define(DUMP_RING_NODE,'storage_1@127.0.0.1').
 -define(RECOVER_NODE,  'storage_2@127.0.0.1').
 -define(TAKEOVER_NODE, 'storage_4@127.0.0.1').
 
@@ -48,6 +49,12 @@ run(?F_CREATE_BUCKET, S3Conf) ->
 run(?F_DELETE_BUCKET, S3Conf) ->
     catch erlcloud_s3:delete_bucket(?env_bucket(), S3Conf),
     timer:sleep(timer:seconds(10)),
+    ok;
+run(?F_DUMP_RING, _S3Conf) ->
+    {ok, _} = libleofs:dump_ring(?S3_HOST, ?LEOFS_ADM_JSON_PORT, atom_to_list(?DUMP_RING_NODE)),
+    Dir = lists:append([?env_leofs_dir(), "/leo_storage_1/log/ring"]),
+    {ok, DumpFiles} = file:list_dir(Dir),
+    [{ok, _} = file:consult(lists:append([Dir, "/", F])) || F <- DumpFiles],
     ok;
 run(?F_PURGE_CACHE, S3Conf) ->
     %% PUT


### PR DESCRIPTION
Please review and merge after https://github.com/leo-project/leofs/pull/1067 get merged as this PR depends on that. 

also make sure that memory cache on leo_gateway is set to enable as the purge-cache test suites depends on memory cache feature.

### New test suites
- purge_cache
- dump_ring
- update_log_level