### PR TITLE
Fixed for leo-project/leofs/issues/1130

### DIFF
--- a/src/leofs_test_commons.erl
+++ b/src/leofs_test_commons.erl
@@ -416,7 +416,7 @@ run(?F_MP_UPLOAD_ABORT, S3Conf) ->
         Results = [begin
                        {ok, Redundancies} = rpc:call(?env_manager(), leo_manager_api, whereis, [[Key4Chunk], true]),
                        case lists:any(
-                              fun({_, not_found}) ->
+                              fun({_, {error, not_found}}) ->
                                       true;
                                  ({_, Fields}) when is_list(Fields) ->
                                       case proplists:get_value(del, Fields, 0) of


### PR DESCRIPTION
I've found a result of `leo_manager_api:whereis/2` does not match with [419L](https://github.com/leo-project/leofs_test2/pull/11/files#diff-8588204500a8024579fbd93071468aabL419):

- [apps/leo_manager/src/leo_manager_api.erl#L1450](https://github.com/leo-project/leofs/blob/v1/apps/leo_manager/src/leo_manager_api.erl#L1450)